### PR TITLE
Added nodejs:10-SCL imagestream tag 

### DIFF
--- a/imagestreams/nodejs-rhel7.json
+++ b/imagestreams/nodejs-rhel7.json
@@ -22,7 +22,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "10"
+          "name": "10-SCL"
         },
         "referencePolicy": {
           "type": "Local"
@@ -73,13 +73,32 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "description": "Build and run Node.js 10 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/nodeshift/centos7-s2i-nodejs.",
           "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
+          "tags": "builder,nodejs,hidden",
           "version": "10",
           "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/rhoar-nodejs/nodejs-10"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10-SCL",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 10",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 10 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/nodeshift/centos7-s2i-nodejs.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "10",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/nodejs-10-rhel7"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Given that the node.js 10 image is now available from SCL, added the SCL Node.js 10 image with `10-SCL` tag to the nodejs imagestream and updated the `latest` tag to point to it.